### PR TITLE
Feature/gene names from uniprot

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,9 +27,7 @@ pipeline{
 		stage('Setup: Build jar file') {
 			steps {
 				script {
-					dir ('orthopairs') {
-							sh "mvn clean compile assembly:single"
-					}
+					sh "mvn clean compile assembly:single"
 				}
 			}
 		}
@@ -37,11 +35,9 @@ pipeline{
 		stage('Main: Generate Orthopairs files') {
 			steps {
 				script {
-					dir ('orthopairs') {
-						// The credentials used here are a config file uploaded to Jenkins.
-						withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]) {
-							sh "java -jar target/orthopairs-${env.ORTHOPAIRS_VERSION}-jar-with-dependencies.jar $ConfigFile"
-						}
+					// The credentials used here are a config file uploaded to Jenkins.
+					withCredentials([file(credentialsId: 'Config', variable: 'ConfigFile')]) {
+						sh "java -jar target/orthopairs-*-jar-with-dependencies.jar $ConfigFile"
 					}
 				}
 			}

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,20 @@
 			<version>${powermock.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>uk.ac.ebi.uniprot</groupId>
+			<artifactId>japi</artifactId>
+			<version>1.0.30</version>
+		</dependency>
 	</dependencies>
+
+	<repositories>
+		<repository>
+			<id>ebi-repo</id>
+			<name>ebi-repo</name>
+			<url>http://www.ebi.ac.uk/~maven/m2repo</url>
+		</repository>
+	</repositories>
 
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,13 @@
 			<artifactId>japi</artifactId>
 			<version>1.0.30</version>
 		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest</artifactId>
+			<version>2.1</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<repositories>

--- a/src/main/java/org/reactome/release/orthopairs/Main.java
+++ b/src/main/java/org/reactome/release/orthopairs/Main.java
@@ -54,7 +54,7 @@ public class Main
 
     private static final Logger logger = LogManager.getLogger();
 
-
+    //TODO: Add Exception commenting
     public static void main( String[] args ) throws IOException, ParseException, ServiceException, InterruptedException {
 
         // If using an alternative source species, specify the 4-letter code as the second argument
@@ -118,7 +118,6 @@ public class Main
 
         // Produces the protein homology, species gene-protein  and gene name mapping files
         for (Object speciesKey : speciesJSONFile.keySet()) {
-
             // No point in the source species mapping to itself
             if (!speciesKey.equals(sourceMappingSpecies)) {
 
@@ -137,7 +136,6 @@ public class Main
                 // Queries UniProt API for gene names and creates the {targetSpecies}_gene_name_mapping.tsv file
                 logger.info("Retrieving gene names for " + speciesNames.get(0) + " from UniProt");
                 UniProtGeneNamesRetriever.retrieveAndStoreGeneNameMappings(speciesKey.toString(), releaseNumber, sourceTargetProteinHomologs.get(speciesPantherName));
-
             }
         }
 

--- a/src/main/java/org/reactome/release/orthopairs/UniProtGeneNamesRetriever.java
+++ b/src/main/java/org/reactome/release/orthopairs/UniProtGeneNamesRetriever.java
@@ -28,7 +28,7 @@ public class UniProtGeneNamesRetriever {
     /**
      * Queries the UniProt mapping service through their Java API library. All Uniprot accession IDs are taken from the Panther
      * homolog files and used to query UniProt for the associated Gene Name. At time of writing (February 2020) this takes about
-     * 2 hours to complete. The end result is a {targetSpecies}_gene_name_mapping.tsv file for each species.
+     * 3 hours to complete. The end result is a {targetSpecies}_gene_name_mapping.tsv file for each species.
      * @param speciesKey String - Shortened version of species name (eg: Bos taurus --> btau).
      * @param releaseNumber String - Used to create a directory where the produced files are stored.
      * @param pantherHomologMappings Map<String, Set<String>> - Species-specific homolog mappings.
@@ -79,14 +79,13 @@ public class UniProtGeneNamesRetriever {
      * @param pantherMappings Map<String, Set<String>> - Species-specific homolog mappings.
      * @return Set<String> - All UniProt identifiers in the mapping object.
      */
-    private static Set<String> getUniProtIdentifiers(Map<String, Set<String>> pantherMappings) {
+    public static Set<String> getUniProtIdentifiers(Map<String, Set<String>> pantherMappings) {
         Set<String> uniprotIds = new HashSet<>();
         for (String uniprotKey : pantherMappings.keySet()) {
-            // The mappings at this point are of the form "UniProtKB=123456", so we isolate the identifier.
-            uniprotIds.add(uniprotKey.split("=")[1]);
             for (String uniprotValue : pantherMappings.get(uniprotKey)) {
                 // Some identifiers aren't UniProt, and therefore can't be queried for Gene Names.
                 if (uniprotValue.contains("UniProtKB")) {
+                    // The values at this point are of the form "UniProtKB=123456", so we isolate the identifier.
                     uniprotIds.add(uniprotValue.split("=")[1]);
                 }
             }
@@ -99,7 +98,7 @@ public class UniProtGeneNamesRetriever {
      * @param uniprotIds Set<String> - All unique UniProt identifiers that were in the Panther mapping.
      * @return List<Set<String>> Partitioned UniProt identifiers.
      */
-    private static List<Set<String>> partitionUniProtIdentifiers(Set<String> uniprotIds) {
+    public static List<Set<String>> partitionUniProtIdentifiers(Set<String> uniprotIds) {
         List<Set<String>> partitionedUniProtIds = new ArrayList<>();
         Set<String> partition = new HashSet<>();
         for (String uniprotId : uniprotIds) {
@@ -122,7 +121,7 @@ public class UniProtGeneNamesRetriever {
      * @throws ServiceException - Thrown by UniProtService class if service is unavailable.
      * @throws InterruptedException - Thrown if the Sleep process that occurs after every batch query is interrupted.
      */
-    private static Set<String> retrieveGeneNamesFromUniProt(List<Set<String>> partitionedUniProtIds) throws ServiceException, InterruptedException {
+    public static Set<String> retrieveGeneNamesFromUniProt(List<Set<String>> partitionedUniProtIds) throws ServiceException, InterruptedException {
 
         // Create the UniProtService.
         ServiceFactory serviceFactoryInstance = Client.getServiceFactoryInstance();

--- a/src/main/java/org/reactome/release/orthopairs/UniProtGeneNamesRetriever.java
+++ b/src/main/java/org/reactome/release/orthopairs/UniProtGeneNamesRetriever.java
@@ -1,0 +1,179 @@
+package org.reactome.release.orthopairs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import uk.ac.ebi.kraken.interfaces.uniprot.Gene;
+import uk.ac.ebi.uniprot.dataservice.client.Client;
+import uk.ac.ebi.uniprot.dataservice.client.QueryResult;
+import uk.ac.ebi.uniprot.dataservice.client.ServiceFactory;
+import uk.ac.ebi.uniprot.dataservice.client.exception.ServiceException;
+import uk.ac.ebi.uniprot.dataservice.client.uniprot.UniProtComponent;
+import uk.ac.ebi.uniprot.dataservice.client.uniprot.UniProtQueryBuilder;
+import uk.ac.ebi.uniprot.dataservice.client.uniprot.UniProtService;
+import uk.ac.ebi.uniprot.dataservice.query.Query;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.time.Duration;
+import java.util.*;
+
+public class UniProtGeneNamesRetriever {
+
+    private static final Logger logger = LogManager.getLogger();
+    private static final int MAX_UNIPROT_BATCH_QUERY_SIZE = 250;
+
+    /**
+     * Queries the UniProt mapping service through their Java API library. All Uniprot accession IDs are taken from the Panther
+     * homolog files and used to query UniProt for the associated Gene Name. At time of writing (February 2020) this takes about
+     * 2 hours to complete. The end result is a {targetSpecies}_gene_name_mapping.tsv file for each species.
+     * @param speciesKey String - Shortened version of species name (eg: Bos taurus --> btau).
+     * @param releaseNumber String - Used to create a directory where the produced files are stored.
+     * @param pantherHomologMappings Map<String, Set<String>> - Species-specific homolog mappings.
+     * @throws ServiceException - Thrown by UniProtService class if service is unavailable.
+     * @throws InterruptedException - Thrown if the Sleep process that occurs after every batch query is interrupted.
+     * @throws IOException - Thrown if unable to create/write to the mapping files.
+     */
+    public static void retrieveAndStoreGeneNameMappings(String speciesKey, String releaseNumber, Map<String, Set<String>> pantherHomologMappings) throws ServiceException, InterruptedException, IOException {
+
+        // Get all gene names associated with all UniProt identifiers.
+        Set<String> uniprotAccessionsToGeneNames = retrieveGeneNameMappings(pantherHomologMappings);
+        // Store results to {targetSpecies}_gene_name_mapping.tsv file.
+        storeGeneNameMappings(speciesKey, releaseNumber, uniprotAccessionsToGeneNames);
+    }
+
+    /**
+     * Organizes all UniProt identifiers in the pantherMappings object into chunks of 250 identifiers. This is due to a
+     * restriction in the size each query to UniProt can have.
+     * @param pantherMappings Map<String, Set<String>> - Species-specific homolog mappings.
+     * @return Set<String> - UniProt-Gene name mappings that will be written to file.
+     * @throws ServiceException - Thrown by UniProtService class if service is unavailable.
+     * @throws InterruptedException - Thrown if the Sleep process that occurs after every batch query is interrupted.
+     */
+    private static Set<String> retrieveGeneNameMappings(Map<String, Set<String>> pantherMappings) throws ServiceException, InterruptedException {
+        // Get all UniProt identifiers and organize them into a List of Sets that contain 250 UniProt identifiers each.
+        List<Set<String>> partitionedUniProtIds = getPartitionedUniProtIdentifiers(pantherMappings);
+        // Query UniProt for gene names associated with UniProt identifiers.
+        return retrieveGeneNamesFromUniProt(partitionedUniProtIds);
+
+    }
+
+    /**
+     * Get all UniProt identifiers in pantherMappings and then partition them into chunks of 250 identifiers.
+     * @param pantherMappings Map<String, Set<String>> - Species-specific homolog mappings.
+     * @return <List><Set<String>> Partitioned UniProt identifiers.
+     */
+    private static List<Set<String>> getPartitionedUniProtIdentifiers(Map<String, Set<String>> pantherMappings) {
+
+        // Get all UniProt identifiers in the Map, removing duplicates.
+        Set<String> uniprotIds = getUniProtIdentifiers(pantherMappings);
+        logger.info("Found " + uniprotIds.size() + " UniProt accessions");
+        // Partition the UniProt identifiers into chunks of 250.
+        return partitionUniProtIdentifiers(uniprotIds);
+    }
+
+    /**
+     * Get all UniProt identifiers in pantherMappings.
+     * @param pantherMappings Map<String, Set<String>> - Species-specific homolog mappings.
+     * @return Set<String> - All UniProt identifiers in the mapping object.
+     */
+    private static Set<String> getUniProtIdentifiers(Map<String, Set<String>> pantherMappings) {
+        Set<String> uniprotIds = new HashSet<>();
+        for (String uniprotKey : pantherMappings.keySet()) {
+            // The mappings at this point are of the form "UniProtKB=123456", so we isolate the identifier.
+            uniprotIds.add(uniprotKey.split("=")[1]);
+            for (String uniprotValue : pantherMappings.get(uniprotKey)) {
+                // Some identifiers aren't UniProt, and therefore can't be queried for Gene Names.
+                if (uniprotValue.contains("UniProtKB")) {
+                    uniprotIds.add(uniprotValue.split("=")[1]);
+                }
+            }
+        }
+        return uniprotIds;
+    }
+
+    /**
+     * Partition all UniProt identifiers into 250-identifier chunks, and add each chunk to a List object.
+     * @param uniprotIds Set<String> - All unique UniProt identifiers that were in the Panther mapping.
+     * @return List<Set<String>> Partitioned UniProt identifiers.
+     */
+    private static List<Set<String>> partitionUniProtIdentifiers(Set<String> uniprotIds) {
+        List<Set<String>> partitionedUniProtIds = new ArrayList<>();
+        Set<String> partition = new HashSet<>();
+        for (String uniprotId : uniprotIds) {
+            partition.add(uniprotId);
+            // Once the partition has 250 identifiers, add it to the List and reset the partition variable.
+            if (partition.size() == MAX_UNIPROT_BATCH_QUERY_SIZE) {
+                partitionedUniProtIds.add(partition);
+                partition = new HashSet<>();
+            }
+        }
+        // The final identifiers at the end are added to the List here.
+        partitionedUniProtIds.add(partition);
+        return partitionedUniProtIds;
+    }
+
+    /**
+     * Query UniProt via the Java API for gene names using UniProt accession IDs.
+     * @param partitionedUniProtIds List<Set<String>> Partitioned UniProt identifiers.
+     * @return Set<String> - Accession-to-Name mappings that will be stored to a file.
+     * @throws ServiceException - Thrown by UniProtService class if service is unavailable.
+     * @throws InterruptedException - Thrown if the Sleep process that occurs after every batch query is interrupted.
+     */
+    private static Set<String> retrieveGeneNamesFromUniProt(List<Set<String>> partitionedUniProtIds) throws ServiceException, InterruptedException {
+
+        // Create the UniProtService.
+        ServiceFactory serviceFactoryInstance = Client.getServiceFactoryInstance();
+        UniProtService uniprotService = serviceFactoryInstance.getUniProtQueryService();
+        uniprotService.start();
+        int count = 0;
+        Set<String> uniprotAccessionsToGeneNames = new HashSet<>();
+        for (Set<String> uniprotIdentifierPartition : partitionedUniProtIds) {
+            // Build UniProt API query from Set of 250 UniProt identifiers.
+            Query query = UniProtQueryBuilder.accessions(uniprotIdentifierPartition);
+            // Perform UniProt API query to retrieve gene names associated with identifiers.
+            QueryResult<UniProtComponent<Gene>> uniprotEntries = uniprotService.getGenes(query);
+
+            while (uniprotEntries.hasNext()) {
+                count++;
+                // Get Gene object returned from UniProt.
+                UniProtComponent<Gene> geneObject = uniprotEntries.next();
+                if (!geneObject.getComponent().isEmpty()) {
+                    // Iterate through all Gene components in the response.
+                    for (Gene geneComponent : geneObject.getComponent()) {
+                        // Tab-separate UniProt accession ID and its associated gene name, and then store these in the Set that will be returned.
+                        uniprotAccessionsToGeneNames.add(geneObject.getAccession().toString() + "\t" + geneComponent.getGeneName().toString() + "\n");
+                    }
+                }
+
+                if (count % 1000 == 0) {
+                    logger.info(count + " UniProt identifiers have been processed");
+                }
+            }
+            // UniProt has a 200 requests/second limit for their API. Chances are we don't need this restriction, but its polite!
+            final long QUERY_SLEEP_DURATION = Duration.ofSeconds(2).toMillis();
+            Thread.sleep(QUERY_SLEEP_DURATION);
+        }
+        uniprotService.stop();
+
+        return uniprotAccessionsToGeneNames;
+    }
+
+    /**
+     * Write the UniProt-gene name mappings to the {targetSpecies}_gene_name_mapping.tsv file.
+     * @param speciesKey String - Shortened version of species name.
+     * @param releaseNumber String - Used to create a directory where the produced files are stored.
+     * @param uniprotAccessionsToGeneNames Set<String> - Accession-to-Name mappings that will be written to a file.
+     * @throws IOException - Thrown if unable to create/write to the mapping files.
+     */
+    private static void storeGeneNameMappings(String speciesKey, String releaseNumber, Set<String> uniprotAccessionsToGeneNames) throws IOException {
+
+        Path uniprotAccessionsToGeneNamesFilePath = Paths.get(releaseNumber, speciesKey + "_gene_name_mapping.tsv");
+        Files.deleteIfExists(uniprotAccessionsToGeneNamesFilePath);
+        for (String uniprotAccessionsToGeneNamesLine : uniprotAccessionsToGeneNames) {
+            Files.write(uniprotAccessionsToGeneNamesFilePath, uniprotAccessionsToGeneNamesLine.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        }
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,1 @@
+<configuration><logger name="org.apache" level="WARN"/><logger name="httpclient" level="WARN"/></configuration>

--- a/src/test/java/org/reactome/release/orthopairs/UniProtGeneNamesRetrieverTest.java
+++ b/src/test/java/org/reactome/release/orthopairs/UniProtGeneNamesRetrieverTest.java
@@ -1,0 +1,78 @@
+package org.reactome.release.orthopairs;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class UniProtGeneNamesRetrieverTest {
+
+    @Test
+    public void testGetUniProtIdentifiers() {
+
+        Set<String> testProteinIds = new HashSet<>(Arrays.asList("UniProtKB=12345"));
+        Map<String, Set<String>> fakePantherMappings = new HashMap<>();
+        fakePantherMappings.put("testKey", testProteinIds);
+
+        Set<String> testUniProtIds = UniProtGeneNamesRetriever.getUniProtIdentifiers(fakePantherMappings);
+
+        assertThat(testUniProtIds, hasSize(1));
+        assertThat(testUniProtIds.contains("12345"), is(equalTo(true)));
+    }
+
+    @Test
+    public void testGetUniProtIdentifiersReturnsOnlyUniProtValues() {
+        Set<String> testProteinIds = new HashSet<>(Arrays.asList("UniProtKB=12345", "UniProtKB=67890", "NotARealKB=13579"));
+        Map<String, Set<String>> fakePantherMappings = new HashMap<>();
+        fakePantherMappings.put("testKey", testProteinIds);
+
+        Set<String> testUniProtIds = UniProtGeneNamesRetriever.getUniProtIdentifiers(fakePantherMappings);
+
+        assertThat(testUniProtIds, hasSize(2));
+        assertThat(testUniProtIds.contains("13579"), is(equalTo(false)));
+    }
+
+    @Test
+    public void testGetUniProtIdentifiersRemovesDuplicates() {
+        Set<String> testProteinIds1 = new HashSet<>(Arrays.asList("UniProtKB=12345", "UniProtKB=67890"));
+        Set<String> testProteinIds2 = new HashSet<>(Arrays.asList("UniProtKB=12345"));
+        Map<String, Set<String>> fakePantherMappings = new HashMap<>();
+        fakePantherMappings.put("testKey1", testProteinIds1);
+        fakePantherMappings.put("testKey2", testProteinIds2);
+
+        Set<String> testUniProtIds = UniProtGeneNamesRetriever.getUniProtIdentifiers(fakePantherMappings);
+
+        assertThat(testUniProtIds, hasSize(2));
+    }
+
+    @Test
+    public void testPartitionUniProtIdentifiers() {
+
+        Set<String> testUniProtIds = new HashSet<>();
+        for (int i = 0; i < 950; i++) {
+            testUniProtIds.add("test" + i);
+        }
+
+        List<Set<String>> testPartitionedUniProtIds = UniProtGeneNamesRetriever.partitionUniProtIdentifiers(testUniProtIds);
+
+        assertThat(testPartitionedUniProtIds, hasSize(4));
+        // Since the total number of values added to the 'testUniProtIds' Set (950) does not cleanly divide
+        // by 250 (max # of identifiers allowed per UniProt query), the last partition should be the remainder (200).
+        assertThat(testPartitionedUniProtIds.get(3).size(), is(equalTo(200)));
+    }
+
+    @Test
+    public void testPartitionUniProtIdentifiersRemovesDuplicates() {
+        Set<String> testUniProtIds = new HashSet<>();
+        for (int i = 0; i < 300; i++) {
+            testUniProtIds.add("test");
+        }
+
+        List<Set<String>> testPartitionedUniProtIds = UniProtGeneNamesRetriever.partitionUniProtIdentifiers(testUniProtIds);
+
+        assertThat(testPartitionedUniProtIds, hasSize(1));
+        assertThat(testPartitionedUniProtIds.get(0).size(), is(equalTo(1)));
+    }
+}


### PR DESCRIPTION
Orthopairs now retrieves gene names from UniProt using the accession IDs taken from the PANTHER file. These are written to their own tab-separated file (rather than incorporated into the Orthopairs files) that are titled like xtro_gene_name_mapping.tsv.

Next, I need to incorporate these gene names into orthoinference, but that should be a relatively small PR.